### PR TITLE
fix(api): rename 'style' to 'cssId' in removeCssFromTab for clarity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export const executeInTab: (
 ) => Promise<{ success: boolean; result: any }> = api.executeInTab;
 
 export const injectCssIntoTab: (tab: string, style: string) => string = api.injectCssIntoTab;
-export const removeCssFromTab: (tab: string, style: string) => void = api.removeCssFromTab;
+export const removeCssFromTab: (tab: string, cssId: string) => void = api.removeCssFromTab;
 
 export const fetchNoCors: (input: string, init?: DeckyRequestInit | undefined) => Promise<Response> = api.fetchNoCors;
 export const getExternalResourceURL: (url: string) => string = api.getExternalResourceURL;


### PR DESCRIPTION
`removeCssFromTab` in Decky Loader API uses `style` as the argument name, which is misleading.

As per [decky-loader/frontend/src/plugin-loader.tsx:](https://github.com/SteamDeckHomebrew/decky-loader/blob/054517595d7e50f3354d3eeeea8da1567e0b0dfc/frontend/src/plugin-loader.tsx#L670)
```
removeCssFromTab: DeckyBackend.callable<[tab: string, cssId: string]>('utilities/remove_css_from_tab')
````